### PR TITLE
Reorganize web app structure

### DIFF
--- a/web/backend/__init__.py
+++ b/web/backend/__init__.py
@@ -1,0 +1,111 @@
+"""Flask backend providing a minimal web UI to play 2048 with an AI agent."""
+
+from flask import Flask, request, jsonify, render_template
+import os
+import numpy as np
+from board import Board
+from agent import DQNAgent
+
+# Mapping index positions returned by the agent to actual move strings
+ACTIONS = ["up", "down", "left", "right"]
+
+# Initialize the Flask application and register templates/static folders
+app = Flask(__name__, template_folder="../templates", static_folder="../static")
+
+board = None  # Will hold the Board instance once a game starts
+agent = None  # Loaded DQNAgent controlling the AI
+
+
+def get_valid_moves(b: Board) -> list[int]:
+    """Return a list of valid move indices for the current board state."""
+    valid_moves: list[int] = []
+    for idx, action in enumerate(ACTIONS):
+        board_copy = np.copy(b.board)
+
+        if action == "up":
+            b.move_up()
+        elif action == "down":
+            b.move_down()
+        elif action == "left":
+            b.move_left()
+        elif action == "right":
+            b.move_right()
+
+        if not np.array_equal(board_copy, b.board):
+            valid_moves.append(idx)
+
+        b.board = board_copy
+
+    return valid_moves
+
+
+@app.route("/")
+def index() -> str:
+    """Serve the main HTML page."""
+    return render_template("index.html")
+
+
+@app.route("/models")
+def models() -> list[str]:
+    """Return a list of available model files."""
+    files = [f for f in os.listdir("models") if f.endswith(".h5")]
+    files.sort()
+    return jsonify(files)
+
+
+@app.route("/start", methods=["POST"])
+def start() -> dict:
+    """Initialize a new game and optionally load an AI model."""
+    global board, agent
+    data = request.get_json()
+    model_name = data.get("model")
+
+    board = Board()
+    board.add_random_tile()
+    board.add_random_tile()
+
+    agent = DQNAgent(state_size=16, action_size=4)
+    if model_name:
+        path = os.path.join("models", model_name)
+        agent.load(path)
+
+    # Disable exploration for deterministic play
+    agent.epsilon = 0.0
+
+    return jsonify({"board": board.board.tolist()})
+
+
+@app.route("/move", methods=["POST"])
+def move() -> dict:
+    """Perform a user-triggered move."""
+    global board
+    data = request.get_json()
+    direction = data.get("direction")
+    if direction in ACTIONS and board is not None:
+        board.move(direction)
+    return jsonify({"board": board.board.tolist()})
+
+
+@app.route("/ai_move", methods=["POST"])
+def ai_move() -> dict:
+    """Have the AI choose and execute the next move."""
+    global board, agent
+
+    if board is None or agent is None:
+        return jsonify({"error": "Game not started"}), 400
+
+    state = board.get_board_state()
+    valid_moves = get_valid_moves(board)
+    if not valid_moves:
+        return jsonify({"board": board.board.tolist(), "action": None})
+
+    action_idx = agent.act(state, valid_moves)
+    action = ACTIONS[action_idx]
+    board.move(action)
+
+    return jsonify({"board": board.board.tolist(), "action": action})
+
+
+if __name__ == "__main__":
+    # When executed directly, start the development server
+    app.run(debug=True)

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1,0 +1,17 @@
+body { font-family: Arial, sans-serif; }
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 80px);
+  gap: 5px;
+  margin-top: 20px;
+}
+.tile {
+  width: 80px;
+  height: 80px;
+  background: #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: bold;
+}

--- a/web/static/js/game.js
+++ b/web/static/js/game.js
@@ -1,0 +1,56 @@
+async function loadModels() {
+  const res = await fetch('/models');
+  const models = await res.json();
+  const sel = document.getElementById('model-select');
+  models.forEach(m => {
+    const opt = document.createElement('option');
+    opt.value = m;
+    opt.textContent = m;
+    sel.appendChild(opt);
+  });
+}
+
+function renderBoard(board) {
+  const grid = document.getElementById('board');
+  grid.innerHTML = '';
+  board.flat().forEach(val => {
+    const cell = document.createElement('div');
+    cell.className = 'tile';
+    cell.textContent = val === 0 ? '' : val;
+    grid.appendChild(cell);
+  });
+}
+
+document.getElementById('start-btn').onclick = async () => {
+  const model = document.getElementById('model-select').value;
+  const res = await fetch('/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model })
+  });
+  const data = await res.json();
+  renderBoard(data.board);
+  document.getElementById('ai-btn').disabled = false;
+};
+
+document.getElementById('ai-btn').onclick = async () => {
+  const res = await fetch('/ai_move', { method: 'POST' });
+  const data = await res.json();
+  renderBoard(data.board);
+};
+
+document.addEventListener('keydown', async e => {
+  const map = { ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right' };
+  if (map[e.key]) {
+    const res = await fetch('/move', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ direction: map[e.key] })
+    });
+    const data = await res.json();
+    renderBoard(data.board);
+    e.preventDefault();
+  }
+});
+
+loadModels();

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,20 @@
+<!-- Minimal front-end for 2048 web game -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>2048 Web</title>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+<h1>2048 Web</h1>
+<div>
+<label for="model-select">Choose AI model:</label>
+<select id="model-select"></select>
+<button id="start-btn">Start Game</button>
+<button id="ai-btn" disabled>AI Move</button>
+</div>
+<div class="grid" id="board"></div>
+<script src="{{ url_for('static', filename='js/game.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- reorganize Flask server into `web/backend` package
- move JS and CSS into new `web/static` folder
- update HTML to reference static resources
- add comments throughout server code

## Testing
- `python -m py_compile web/backend/__init__.py`
- `python web/backend/__init__.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848e958c82c8321b3dfbe43b30261c7